### PR TITLE
add metainfo file for flatpak/flathub

### DIFF
--- a/io.github.wwmm.easyeffects.Presets.LoudnessEqualizer.metainfo.xml
+++ b/io.github.wwmm.easyeffects.Presets.LoudnessEqualizer.metainfo.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>io.github.wwmm.easyeffects.Presets.LoudnessEqualizer</id>
+  <extends>com.github.wwmm.easyeffects</extends>
+  <name>Loudness Equalizer Easy Effects Presets</name>
+  <developer id="io.github.digitalone1">
+    <name>Giusy Digital</name>
+  </developer>
+  <summary>A Loudness Equalizer preset which performs automatic volume adjustment without the Auto Gain effect</summary>
+  <url type="homepage">https://github.com/Digitalone1/EasyEffects-Presets</url>
+  <url type="vcs-browser">https://github.com/Digitalone1/EasyEffects-Presets</url>
+  <url type="help">https://github.com/Digitalone1/EasyEffects-Presets</url>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+</component>


### PR DESCRIPTION
This could be stored downstream in the future flathub repo, but isn't really ideal as this is not flatpak/flathub specific. Feel free to add more information to it so long as it passes:
```
appstreamcli validate io.github.wwmm.easyeffects.LoudnessEqualizer.metainfo.xml
```